### PR TITLE
Update android sdk to 33

### DIFF
--- a/config.cordovabuild.xml
+++ b/config.cordovabuild.xml
@@ -13,11 +13,10 @@
     <preference name="webviewbounce" value="false" />
     <preference name="UIWebViewBounce" value="false" />
     <preference name="DisallowOverscroll" value="true" />
-    <preference name="android-minSdkVersion" value="22" />
     <preference name="BackupWebStorage" value="none" />
     <preference name="emSensorDataCollectionProtocolApprovalDate" value="2016-07-14" />
     <preference name="GradlePluginGoogleServicesEnabled" value="true" />
-    <preference name="GradlePluginGoogleServicesVersion" value="4.3.3" />
+    <preference name="GradlePluginGoogleServicesVersion" value="4.3.15" />
     <config-file parent="/manifest/application" target="AndroidManifest.xml">
         <meta-data android:name="firebase_analytics_collection_deactivated" android:value="true" />
         <meta-data android:name="google_analytics_adid_collection_enabled" android:value="false" />
@@ -48,12 +47,10 @@
     </platform>
     <platform name="android">
         <hook src="hooks/before_build/android/android_copy_locales.js" type="before_build" />
-        <preference name="android-minSdkVersion" value="23" />
-        <preference name="android-targetSdkVersion" value="32" />
         <preference name="AndroidLaunchMode" value="singleInstance"/>
         <preference name="AndroidXEnabled" value="true" />
         <preference name="GradlePluginKotlinEnabled" value="true" />
-        <preference name="GradlePluginKotlinVersion" value="1.7.10" />
+        <preference name="GradlePluginKotlinVersion" value="1.7.21" />
         <resource-file src="google-services.json" target="app/google-services.json" />
         <hook src="hooks/before_build/android/android_set_provider.js" type="before_build" />
         <hook src="hooks/before_build/android/android_change_compile_implementation.js" type="before_build" />

--- a/package.cordovabuild.json
+++ b/package.cordovabuild.json
@@ -27,11 +27,11 @@
       "cordova-plugin-app-version": {},
       "cordova-plugin-file": {},
       "cordova-plugin-device": {},
-      "cordova-plugin-customurlscheme": {	
-        "URL_SCHEME": "emission",	
-        "ANDROID_SCHEME": " ",	
-        "ANDROID_HOST": " ",	
-        "ANDROID_PATHPREFIX": "/"	
+      "cordova-plugin-customurlscheme": {
+        "URL_SCHEME": "emission",
+        "ANDROID_SCHEME": " ",
+        "ANDROID_HOST": " ",
+        "ANDROID_PATHPREFIX": "/"
       },
       "cordova-plugin-email-composer": {},
       "cordova-plugin-x-socialsharing": {
@@ -50,7 +50,7 @@
       },
       "cordova-plugin-em-opcodeauth": {},
       "cordova-plugin-em-server-communication": {},
-      "cordova-plugin-em-datacollection": {	
+      "cordova-plugin-em-datacollection": {
         "LOCATION_VERSION": "21.0.1",
         "ANDROIDX_CORE_VERSION": "1.8.0",
         "ANDROIDX_WORK_VERSION": "2.7.1"
@@ -66,14 +66,14 @@
     }
   },
   "dependencies": {
-    "cordova-android": "11.0.0",
+    "cordova-android": "12.0.0",
     "cordova-ios": "6.2.0",
     "cordova-plugin-advanced-http": "3.3.1",
     "cordova-plugin-androidx-adapter": "1.1.3",
     "cordova-plugin-app-version": "0.1.14",
     "cordova-plugin-customurlscheme": "5.0.2",
     "cordova-plugin-device": "2.1.0",
-    "cordova-plugin-em-datacollection": "git+https://github.com/e-mission/e-mission-data-collection.git#v1.7.7",
+    "cordova-plugin-em-datacollection": "git+https://github.com/e-mission/e-mission-data-collection.git#v1.7.9",
     "cordova-plugin-em-opcodeauth": "git+https://github.com/e-mission/cordova-jwt-auth.git#v1.7.1",
     "cordova-plugin-em-server-communication": "git+https://github.com/e-mission/cordova-server-communication.git#v1.2.5",
     "cordova-plugin-em-serversync": "git+https://github.com/e-mission/cordova-server-sync.git#v1.3.1",
@@ -81,7 +81,7 @@
     "cordova-plugin-em-unifiedlogger": "git+https://github.com/e-mission/cordova-unified-logger.git#v1.3.6",
     "cordova-plugin-em-usercache": "git+https://github.com/e-mission/cordova-usercache.git#v1.1.5",
     "cordova-plugin-email-composer": "git+https://github.com/katzer/cordova-plugin-email-composer.git#0.10.1",
-    "cordova-plugin-file": "7.0.0",
+    "cordova-plugin-file": "8.0.0",
     "cordova-plugin-inappbrowser": "5.0.0",
     "cordova-plugin-ionic-keyboard": "2.2.0",
     "cordova-plugin-ionic-webview": "5.0.0",


### PR DESCRIPTION
This should resolve the google play sdk requirement.
Building after this change may require any already setup project to run:
```
cordova platform remove android
cordova platform add android@12.0.0
```
To adapt to the new cordova android version.

You will also need to install Android SDK 13.0 and build tools 33.0.2 from android studio if you don't have them already.

Some functionality may be compromised by the update. In particular are notifications and file access permissions. 
Notifications seem to be working as intended (as long as the user sets them as the app requests) and file permissions seem unused.

This doesn't align other parts of the upstream so if ever anything doesn't seem to work, there would be where to check. In particular the cordova-plugin-em-** dependencies in package.cordovabuild.json may need updates, among others.